### PR TITLE
Use libfmt instead of string streams in ValueFormatter for speed and …

### DIFF
--- a/smartmet-library-spine.spec
+++ b/smartmet-library-spine.spec
@@ -97,6 +97,9 @@ make %{_smp_mflags}
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Upcoming
+- Use libfmt instead of string streams in ValueFormatter to avoid global locale locks
+
 * Wed Jul  4 2018 Mika Heiskanen <mika.heiskanen@fmi.fi> - 18.7.4-1.fmi
 - Avoid using ostringstream in HTTP code to avoid global locale locks
 

--- a/spine/ValueFormatter.cpp
+++ b/spine/ValueFormatter.cpp
@@ -7,8 +7,8 @@
 #include "ValueFormatter.h"
 #include "Convenience.h"
 #include "Exception.h"
+#include <fmt/format.h>
 #include <cmath>
-#include <iomanip>
 #include <stdexcept>
 
 static int powers_of_ten[] = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000};
@@ -17,21 +17,107 @@ namespace SmartMet
 {
 namespace Spine
 {
+// c++14 would not need this
+ValueFormatterParam::ValueFormatterParam(const std::string& theMissingText,
+                                         const std::string& theAdjustField,
+                                         const std::string& theFloatField,
+                                         int theWidth,
+                                         char theFill,
+                                         bool theShowPos,
+                                         bool theUpperCase)
+    : missingText(theMissingText),
+      adjustField(theAdjustField),
+      floatField(theFloatField),
+      width(theWidth),
+      fill(theFill),
+      showPos(theShowPos),
+      upperCase(theUpperCase)
+{
+}
+
 // ----------------------------------------------------------------------
 /*!
- * \brief Default constructor for ValueFormatterParam
+ * \brief Create libfmt format string from iostream style settings
+ *
+ * Relevant options:
+ *
+ * missingtext - the replacement for NaN
+ * width - the width manipulator argument
+ * fill - the fill manipulator argument
+ * adjustfield - left|right|internal
+ * showpos - true|false
+ * uppercase - true|false
+ * floatfield - fixed|scientific
+ *
+ * From http://fmtlib.net/latest/syntax.html:
+ *
+ * format_spec ::=  [[fill]align][sign]["#"]["0"][width]["." precision][type]
+ * fill        ::=  <a character other than '{' or '}'>
+ * align       ::=  "<" | ">" | "=" | "^"
+ * sign        ::=  "+" | "-" | " "
+ * width       ::=  integer | "{" arg_id "}"
+ * precision   ::=  integer | "{" arg_id "}"
+ * type        ::=  int_type | "a" | "A" | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "p" | "s"
+ * int_type    ::=  "b" | "B" | "d" | "n" | "o" | "x" | "X"
  */
-//-----------------------------------------------------------------------
+// ----------------------------------------------------------------------
 
-ValueFormatterParam::ValueFormatterParam()
-    : missingText("nan"),
-      adjustField("right"),
-      floatField("fixed"),
-      width(-1),
-      fill(' '),
-      showPos(false),
-      upperCase(false)
+void ValueFormatter::buildFormat(const ValueFormatterParam& param)
 {
+  itsMissingText = param.missingText;
+  itsFloatField = param.floatField;
+
+  std::string fmt = "{:";
+
+  if (param.width > 0)
+  {
+    fmt += param.fill;  // fill character
+
+    if (param.adjustField == "left")
+      fmt += '<';
+    else if (param.adjustField == "right")
+      fmt += '>';
+    else if (param.adjustField == "internal")
+      fmt += '=';
+    else if (param.adjustField == "center")  // libfmt extension
+      fmt += '^';
+  }
+
+  if (param.showPos)  // sign for positive numbers
+    fmt += '+';
+
+  if (param.fill == '0')  // sign aware zero padding
+    fmt += '0';
+
+  if (param.width > 0)
+    fmt += fmt::sprintf("%d", param.width);
+
+  char ntype;
+
+  if (param.floatField == "fixed")
+  {
+    if (param.upperCase)
+      ntype = 'F';
+    else
+      ntype = 'f';
+  }
+  else if (param.floatField == "scientific")
+  {
+    if (param.upperCase)
+      ntype = 'E';
+    else
+      ntype = 'e';
+  }
+  else if (param.floatField == "none")
+  {
+    if (param.upperCase)
+      ntype = 'G';
+    else
+      ntype = 'g';
+  }
+
+  itsFormat = fmt + ntype + '}';
+  itsPrecisionFormat = fmt + ".{}" + ntype + '}';
 }
 
 // ----------------------------------------------------------------------
@@ -41,20 +127,22 @@ ValueFormatterParam::ValueFormatterParam()
 // ----------------------------------------------------------------------
 
 ValueFormatter::ValueFormatter(const HTTP::Request& theReq)
-    : itsStream(new std::ostringstream),
-      itsMissingText(optional_string(theReq.getParameter("missingtext"), "nan")),
-      itsWidth(optional_int(theReq.getParameter("width"), -1)),
-      itsFill(optional_char(theReq.getParameter("fill"), ' ')),
-      itsAdjustField(optional_string(theReq.getParameter("adjustfield"), "right")),
-      itsShowPos(optional_bool(theReq.getParameter("showpos"), false)),
-      itsUpperCase(optional_bool(theReq.getParameter("uppercase"), false)),
-      itsFloatField(optional_string(theReq.getParameter("floatfield"), "fixed"))
 {
   try
   {
+    ValueFormatterParam p{optional_string(theReq.getParameter("missingtext"), "nan"),
+                          optional_string(theReq.getParameter("adjustfield"), "right"),
+                          optional_string(theReq.getParameter("floatfield"), "fixed"),
+                          optional_int(theReq.getParameter("width"), -1),
+                          optional_char(theReq.getParameter("fill"), ' '),
+                          optional_bool(theReq.getParameter("showpos"), false),
+                          optional_bool(theReq.getParameter("uppercase"), false)};
+
+    buildFormat(p);
+
     // Override for WXML
     if (optional_string(theReq.getParameter("format"), "") == "WXML")
-      itsMissingText = "NaN";
+      p.missingText = "NaN";
   }
   catch (...)
   {
@@ -69,30 +157,14 @@ ValueFormatter::ValueFormatter(const HTTP::Request& theReq)
 // ----------------------------------------------------------------------
 
 ValueFormatter::ValueFormatter(const ValueFormatterParam& param)
-    : itsStream(new std::ostringstream),
-      itsMissingText(param.missingText),
-      itsWidth(param.width),
-      itsFill(param.fill),
-      itsAdjustField(param.adjustField),
-      itsShowPos(param.showPos),
-      itsUpperCase(param.upperCase),
-      itsFloatField(param.floatField)
 {
+  buildFormat(param);
 }
 
 // ----------------------------------------------------------------------
 /*!
  * \brief Convert a float to a string
  *
- * Relevant options:
- *
- * missingtext - the replacement for NaN
- * width - the width manipulator argument
- * fill - the fill manipulator argument
- * adjustfield - left|right|internal
- * showpos - true|false
- * uppercase - true|false
- * floatfield - fixed|scientific
  */
 // ----------------------------------------------------------------------
 
@@ -103,64 +175,30 @@ std::string ValueFormatter::format(double theValue, int thePrecision) const
     if (isnan(theValue))
       return itsMissingText;
 
-    // shorthand variable to avoid constant dereferencing
-    std::ostringstream& out = *itsStream;
+    if (thePrecision < 0)
+      return fmt::format(itsFormat, theValue);
 
-    double value = theValue;
+    auto value = theValue;
 
-    out.str("");  // empty old contents
-
-    if (itsWidth > 0)
-      out << std::setw(itsWidth);
-
-    if (thePrecision >= 0)
+    // Fix rounding only in fixed (or none) mode and only for reasonable precision settings
+    if ((itsFloatField == "fixed" || itsFloatField == "none") &&
+        (thePrecision >= 1 && thePrecision <= 7))
     {
-      // Fix rounding only in fixed (or none) mode and only for reasonable precision settings
-      if ((itsFloatField == "fixed" || itsFloatField == "none") &&
-          (thePrecision >= 1 && thePrecision <= 7))
+      // Fix rounding issues inherent in floating point arithmetic ->
+      // https://www.dot.nd.gov/manuals/materials/testingmanual/rounding.pdf
+      if (itsFloatField == "none")
       {
-        // Fix rounding issues inherent in floating point arithmetic ->
-        // https://www.dot.nd.gov/manuals/materials/testingmanual/rounding.pdf
-        if (itsFloatField == "none")
-        {
-          value = round(value * powers_of_ten[thePrecision - 1]) /
-                  static_cast<double>(powers_of_ten[thePrecision - 1]);
-        }
-        else
-        {
-          value = round(value * powers_of_ten[thePrecision]) /
-                  static_cast<double>(powers_of_ten[thePrecision]);
-        }
+        value = round(value * powers_of_ten[thePrecision - 1]) /
+                static_cast<double>(powers_of_ten[thePrecision - 1]);
       }
-      out << std::setprecision(thePrecision);
+      else
+      {
+        value = round(value * powers_of_ten[thePrecision]) /
+                static_cast<double>(powers_of_ten[thePrecision]);
+      }
     }
-    if (itsShowPos)
-      out << std::showpos;
-    if (itsUpperCase)
-      out << std::uppercase;
-    out << std::setfill(itsFill);
 
-    if (itsAdjustField == "left")
-      out << std::left;
-    else if (itsAdjustField == "right")
-      out << std::right;
-    else if (itsAdjustField == "internal")
-      out << std::internal;
-    else
-      throw Spine::Exception(BCP, "Unknown adjustfield '" + itsAdjustField + "'");
-
-    if (itsFloatField == "fixed")
-      out << std::fixed;
-    else if (itsFloatField == "scientific")
-      out << std::scientific;
-    else if (itsFloatField == "none")
-      ;
-    else
-      throw Spine::Exception(BCP, "Unknown floatfield '" + itsFloatField + "'");
-
-    out << value;
-
-    return out.str();
+    return fmt::format(itsPrecisionFormat, value, thePrecision);
   }
   catch (...)
   {

--- a/spine/ValueFormatter.h
+++ b/spine/ValueFormatter.h
@@ -17,15 +17,26 @@ namespace Spine
 {
 struct ValueFormatterParam
 {
-  std::string missingText;
-  std::string adjustField;
-  std::string floatField;
-  int width;
-  char fill;
-  bool showPos;
-  bool upperCase;
+  std::string missingText = "nan";
+  std::string adjustField = "right";
+  std::string floatField = "fixed";
+  int width = -1;
+  char fill = ' ';
+  bool showPos = false;
+  bool upperCase = false;
 
-  ValueFormatterParam();
+  // c++14 would not need this, c++11 does because of the defaults above
+  ValueFormatterParam(const std::string& theMissingText,
+                      const std::string& theAdjustField,
+                      const std::string& theFloatField,
+                      int theWidth,
+                      char theFill,
+                      bool theShowPos,
+                      bool theUpperCase);
+
+  // and this is needed because above is needed
+  ValueFormatterParam() = default;
+  ValueFormatterParam(const ValueFormatterParam& theOther) = default;
 };
 
 class ValueFormatter
@@ -40,14 +51,11 @@ class ValueFormatter
 
  private:
   ValueFormatter();
-  boost::shared_ptr<std::ostringstream> itsStream;  // not safe to be used from multiple threads
-  std::string itsMissingText;
-  int itsWidth;
-  char itsFill;
-  std::string itsAdjustField;
-  bool itsShowPos;
-  bool itsUpperCase;
-  std::string itsFloatField;
+  void buildFormat(const ValueFormatterParam& param);
+  std::string itsFormat;           // when no precision is given
+  std::string itsPrecisionFormat;  // when precision is given
+  std::string itsFloatField;       // saved to enable school type rounding fixes
+  std::string itsMissingText;      // text for NaN
 };
 
 }  // namespace Spine

--- a/test/ValueFormatterTest.cpp
+++ b/test/ValueFormatterTest.cpp
@@ -60,7 +60,7 @@ void nan()
     req.setParameter("floatfield", "none");
     SmartMet::Spine::ValueFormatter fmt(req);
     if ((result = fmt.format(nan, precision)) != "nan")
-      TEST_FAILED("Failed to return 'nan' for NaN value");
+      TEST_FAILED("Failed to return 'nan' for NaN value, result = " + result);
   }
 
   {
@@ -69,7 +69,7 @@ void nan()
     req.setParameter("missingtext", "NULL");
     SmartMet::Spine::ValueFormatter fmt(req);
     if ((result = fmt.format(nan, precision)) != "NULL")
-      TEST_FAILED("Failed to return 'NULL' for NaN value");
+      TEST_FAILED("Failed to return 'NULL' for NaN value, result = " + result);
   }
 
   TEST_PASSED();


### PR DESCRIPTION
…to avoid global locale locks (BRAINSTORM-1242)