### PR TITLE
Bugfix and modifications to make grid parameter aliases work (BRAINST…

### DIFF
--- a/smartmet-library-spine.spec
+++ b/smartmet-library-spine.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-library-%{DIRNAME}
 Summary: SmartMet Server core helper classes
 Name: %{SPECNAME}
-Version: 19.10.31
+Version: 19.11.20
 Release: 1%{?dist}.fmi
 License: MIT
 Group: BrainStorm/Development
@@ -100,6 +100,9 @@ make %{_smp_mflags}
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Wed Nov 20 2019 Anssi Reponen <anssi.reponen@fmi.fi> - 19.11.20-1.fmi
+- New data member added in Parameter class (original case sensitive name). Bugfix: don't try to parse nonexistent parameter functions (BRAINSTORM-1726)
+
 * Thu Oct 31 2019 Mika Heiskanen <mika.heiskanen@fmi.fi> - 19.10.31-1.fmi
 - Rebuilt due to newbase API/ABI changes
 

--- a/spine/Parameter.cpp
+++ b/spine/Parameter.cpp
@@ -23,7 +23,11 @@ namespace Spine
 // ----------------------------------------------------------------------
 
 Parameter::Parameter(const std::string& theName, Type theType, FmiParameterName theNumber)
-    : itsName(theName), itsAlias(theName), itsType(theType), itsNumber(theNumber)
+    : itsName(theName),
+      itsOriginalName(theName),
+      itsAlias(theName),
+      itsType(theType),
+      itsNumber(theNumber)
 {
 }
 
@@ -31,7 +35,11 @@ Parameter::Parameter(const std::string& theName,
                      const std::string& theAlias,
                      Type theType,
                      FmiParameterName theNumber)
-    : itsName(theName), itsAlias(theAlias), itsType(theType), itsNumber(theNumber)
+    : itsName(theName),
+      itsOriginalName(theName),
+      itsAlias(theAlias),
+      itsType(theType),
+      itsNumber(theNumber)
 {
 }
 

--- a/spine/Parameter.h
+++ b/spine/Parameter.h
@@ -37,8 +37,10 @@ class Parameter
             FmiParameterName theNumber = kFmiBadParameter);
 
   const std::string& name() const { return itsName; }
+  const std::string& originalName() const { return itsOriginalName; }
   std::string alias() const { return itsAlias; }
   void setAlias(const std::string& name) { itsAlias = name; }
+  void setOriginalName(const std::string& name) { itsOriginalName = name; }
   FmiParameterName number() const { return itsNumber; }
   Type type() const { return itsType; }
   std::string typestring() const;
@@ -54,6 +56,8 @@ class Parameter
   // extended name may contain parameter name with possible
   // function name or alternatively alias given by user
   // for example mean_t(t2m) as tmean
+  // Original name is case sensitive since grid-parameter names may include LUA-function names
+  std::string itsOriginalName;
 
   std::string itsAlias;
   Type itsType;

--- a/spine/ParameterFactory.h
+++ b/spine/ParameterFactory.h
@@ -43,6 +43,7 @@ class ParameterFactory
                                double& theUpperLimit) const;
   FunctionId parse_function(const std::string& theFunction) const;
   std::string parse_parameter_functions(const std::string& theParameterRequest,
+                                        std::string& theOriginalName,
                                         std::string& theParameterNameAlias,
                                         ParameterFunction& thePrimaryParameterFunction,
                                         ParameterFunction& theSecondaryParameterFunction) const;


### PR DESCRIPTION
…ORM-1726)

- Don't try to parse nonexistent parameter functions
- New data member added in Parameter class to store original case sensitive name of parameter