### PR TITLE
Start using local time pool to avoid unnecessary allocations of local…

### DIFF
--- a/smartmet-library-spine.spec
+++ b/smartmet-library-spine.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-library-%{DIRNAME}
 Summary: SmartMet Server core helper classes
 Name: %{SPECNAME}
-Version: 21.7.28
+Version: 21.8.17
 Release: 1%{?dist}.fmi
 License: MIT
 Group: BrainStorm/Development
@@ -109,6 +109,9 @@ make %{_smp_mflags}
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
+* Tue Aug 17 2021 Anssi Reponen <anssi.reponen@fmi.fi> - 21.8.17-1.fmi
+- Start using local time pool to avoid unnecessary allocations of local_date_time objects (BRAINSTORM-2122)
+
 * Wed Jul 28 2021 Mika Heiskanen <mika.heiskanen@fmi.fi> - 21.7.28-1.fmi
 - Silenced several compiler warnings
 - Initialize locations to NaN coordinates by default

--- a/smartmet-library-spine.spec
+++ b/smartmet-library-spine.spec
@@ -3,7 +3,7 @@
 %define SPECNAME smartmet-library-%{DIRNAME}
 Summary: SmartMet Server core helper classes
 Name: %{SPECNAME}
-Version: 21.8.17
+Version: 21.8.19
 Release: 1%{?dist}.fmi
 License: MIT
 Group: BrainStorm/Development
@@ -35,7 +35,7 @@ BuildRequires: libicu-devel
 BuildRequires: make
 BuildRequires: mariadb-devel
 BuildRequires: rpm-build
-BuildRequires: smartmet-library-gis-devel >= 21.7.27
+BuildRequires: smartmet-library-gis-devel >= 21.8.3
 BuildRequires: smartmet-library-macgyver-devel >= 21.8.5
 BuildRequires: smartmet-library-newbase-devel >= 21.6.16
 Requires: boost169-chrono
@@ -54,7 +54,7 @@ Requires: hdf5
 Requires: jsoncpp >= 1.8.4
 Requires: libconfig >= 1.7.2
 Requires: libicu
-Requires: smartmet-library-gis >= 21.7.27
+Requires: smartmet-library-gis >= 21.8.3
 Requires: smartmet-library-macgyver >= 21.8.5
 Requires: smartmet-library-newbase >= 21.6.16
 Requires: smartmet-timezones >= 21.2.2
@@ -109,7 +109,7 @@ make %{_smp_mflags}
 %{_includedir}/smartmet/%{DIRNAME}
 
 %changelog
-* Tue Aug 17 2021 Anssi Reponen <anssi.reponen@fmi.fi> - 21.8.17-1.fmi
+* Thu Aug 19 2021 Mika Heiskanen <mika.heiskanen@fmi.fi> - 21.8.19-1.fmi
 - Start using local time pool to avoid unnecessary allocations of local_date_time objects (BRAINSTORM-2122)
 
 * Wed Jul 28 2021 Mika Heiskanen <mika.heiskanen@fmi.fi> - 21.7.28-1.fmi

--- a/spine/AccessLogger.cpp
+++ b/spine/AccessLogger.cpp
@@ -108,9 +108,12 @@ void AccessLogger::stop()
 
 AccessLogger::~AccessLogger()
 {
-  try {
+  try
+  {
     this->stop();
-  } catch (...) {
+  }
+  catch (...)
+  {
     std::cout << Fmi::Exception::Trace(BCP, "Operation failed!").getStackTrace() << std::endl;
   }
 }

--- a/spine/TimeSeries.cpp
+++ b/spine/TimeSeries.cpp
@@ -1,5 +1,6 @@
 #include "TableFeeder.h"
 #include <boost/make_shared.hpp>
+#include <macgyver/StringConversion.h>
 
 namespace SmartMet
 {
@@ -16,7 +17,7 @@ std::ostream& operator<<(std::ostream& os, const LocalTimePool& localTimePool)
 
 const boost::local_time::local_date_time&  LocalTimePool::create(const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz)
 {
-  std::string key =  (boost::posix_time::to_iso_string(t) + tz->to_posix_string());
+  std::string key =  (Fmi::to_iso_string(t) + tz->to_posix_string());
 
   if(localtimes.find(key) == localtimes.end())
     localtimes.insert(std::make_pair(key, boost::local_time::local_date_time(t, tz)));

--- a/spine/TimeSeries.cpp
+++ b/spine/TimeSeries.cpp
@@ -8,71 +8,78 @@ namespace Spine
 {
 namespace TimeSeries
 {
-  
 std::ostream& operator<<(std::ostream& os, const LocalTimePool& localTimePool)
 {
   localTimePool.print(os);
   return os;
 }
 
-const boost::local_time::local_date_time&  LocalTimePool::create(const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz)
+const boost::local_time::local_date_time& LocalTimePool::create(
+    const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz)
 {
-  std::string key =  (Fmi::to_iso_string(t) + tz->to_posix_string());
+  std::string key = (Fmi::to_iso_string(t) + tz->to_posix_string());
 
-  if(localtimes.find(key) == localtimes.end())
+  if (localtimes.find(key) == localtimes.end())
     localtimes.insert(std::make_pair(key, boost::local_time::local_date_time(t, tz)));
 
   return localtimes.at(key);
 }
 
-size_t LocalTimePool::size() const 
+size_t LocalTimePool::size() const
 {
   return localtimes.size();
 }
 
 void LocalTimePool::print(std::ostream& os) const
 {
-  for(const auto& item : localtimes)
-	os << item.first << " -> " << item.second << std::endl;
+  for (const auto& item : localtimes)
+    os << item.first << " -> " << item.second << std::endl;
 }
 
 TimeSeries::TimeSeries(LocalTimePoolPtr time_pool)
 {
   local_time_pool = time_pool;
 }
-  
+
 void TimeSeries::emplace_back(const TimedValue& tv)
 {
-  TimedValueVector::emplace_back(TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+  TimedValueVector::emplace_back(
+      TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()), tv.value));
 }
-  
+
 void TimeSeries::push_back(const TimedValue& tv)
 {
-  TimedValueVector::push_back(TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+  TimedValueVector::push_back(
+      TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()), tv.value));
 }
 
 TimedValueVector::iterator TimeSeries::insert(TimedValueVector::iterator pos, const TimedValue& tv)
 {
-  return TimedValueVector::insert(pos, TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+  return TimedValueVector::insert(
+      pos, TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()), tv.value));
 }
 
-void TimeSeries::insert(TimedValueVector::iterator pos, TimedValueVector::iterator first, TimedValueVector::iterator last)
+void TimeSeries::insert(TimedValueVector::iterator pos,
+                        TimedValueVector::iterator first,
+                        TimedValueVector::iterator last)
 {
   TimedValueVector::insert(pos, first, last);
 }
 
-void TimeSeries::insert(TimedValueVector::iterator pos, TimedValueVector::const_iterator first, TimedValueVector::const_iterator last)
+void TimeSeries::insert(TimedValueVector::iterator pos,
+                        TimedValueVector::const_iterator first,
+                        TimedValueVector::const_iterator last)
 {
   TimedValueVector::insert(pos, first, last);
 }
 
-TimeSeries& TimeSeries::operator=(const TimeSeries& ts) 
+TimeSeries& TimeSeries::operator=(const TimeSeries& ts)
 {
   clear();
-  TimedValueVector::insert(end(), ts.begin(), ts.end());  
+  TimedValueVector::insert(end(), ts.begin(), ts.end());
   local_time_pool = ts.local_time_pool;
 
-  return *this; 
+  return *this;
 }
 
 bool operator==(const LonLat& lonlat1, const LonLat& lonlat2)

--- a/spine/TimeSeries.cpp
+++ b/spine/TimeSeries.cpp
@@ -1,4 +1,5 @@
 #include "TableFeeder.h"
+#include <boost/make_shared.hpp>
 
 namespace SmartMet
 {
@@ -6,6 +7,73 @@ namespace Spine
 {
 namespace TimeSeries
 {
+  
+std::ostream& operator<<(std::ostream& os, const LocalTimePool& localTimePool)
+{
+  localTimePool.print(os);
+  return os;
+}
+
+const boost::local_time::local_date_time&  LocalTimePool::create(const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz)
+{
+  std::string key =  (boost::posix_time::to_iso_string(t) + tz->to_posix_string());
+
+  if(localtimes.find(key) == localtimes.end())
+    localtimes.insert(std::make_pair(key, boost::local_time::local_date_time(t, tz)));
+
+  return localtimes.at(key);
+}
+
+size_t LocalTimePool::size() const 
+{
+  return localtimes.size();
+}
+
+void LocalTimePool::print(std::ostream& os) const
+{
+  for(const auto& item : localtimes)
+	os << item.first << " -> " << item.second << std::endl;
+}
+
+TimeSeries::TimeSeries(LocalTimePoolPtr time_pool)
+{
+  local_time_pool = time_pool;
+}
+  
+void TimeSeries::emplace_back(const TimedValue& tv)
+{
+  TimedValueVector::emplace_back(TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+}
+  
+void TimeSeries::push_back(const TimedValue& tv)
+{
+  TimedValueVector::push_back(TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+}
+
+TimedValueVector::iterator TimeSeries::insert(TimedValueVector::iterator pos, const TimedValue& tv)
+{
+  return TimedValueVector::insert(pos, TimedValue(local_time_pool->create(tv.time.utc_time(), tv.time.zone()),tv.value));
+}
+
+void TimeSeries::insert(TimedValueVector::iterator pos, TimedValueVector::iterator first, TimedValueVector::iterator last)
+{
+  TimedValueVector::insert(pos, first, last);
+}
+
+void TimeSeries::insert(TimedValueVector::iterator pos, TimedValueVector::const_iterator first, TimedValueVector::const_iterator last)
+{
+  TimedValueVector::insert(pos, first, last);
+}
+
+TimeSeries& TimeSeries::operator=(const TimeSeries& ts) 
+{
+  clear();
+  TimedValueVector::insert(end(), ts.begin(), ts.end());  
+  local_time_pool = ts.local_time_pool;
+
+  return *this; 
+}
+
 bool operator==(const LonLat& lonlat1, const LonLat& lonlat2)
 {
   return (lonlat1.lon == lonlat2.lon && lonlat1.lat == lonlat2.lat);

--- a/spine/TimeSeries.cpp
+++ b/spine/TimeSeries.cpp
@@ -1,6 +1,6 @@
 #include "TableFeeder.h"
 #include <boost/make_shared.hpp>
-#include <macgyver/StringConversion.h>
+#include <macgyver/Hash.h>
 
 namespace SmartMet
 {
@@ -17,7 +17,8 @@ std::ostream& operator<<(std::ostream& os, const LocalTimePool& localTimePool)
 const boost::local_time::local_date_time& LocalTimePool::create(
     const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz)
 {
-  std::string key = (Fmi::to_iso_string(t) + tz->to_posix_string());
+  auto key = Fmi::hash_value(t);
+  Fmi::hash_combine(key, Fmi::hash_value(tz));
 
   if (localtimes.find(key) == localtimes.end())
     localtimes.insert(std::make_pair(key, boost::local_time::local_date_time(t, tz)));

--- a/spine/TimeSeries.h
+++ b/spine/TimeSeries.h
@@ -53,7 +53,7 @@ class LocalTimePool
   void print(std::ostream& os) const;
 
  private:
-  std::map<std::string, boost::local_time::local_date_time> localtimes;
+  std::map<std::size_t, boost::local_time::local_date_time> localtimes;
 };
 
 using LocalTimePoolPtr = boost::shared_ptr<LocalTimePool>;

--- a/spine/TimeSeries.h
+++ b/spine/TimeSeries.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/variant.hpp>
@@ -43,15 +43,16 @@ struct None
 using Value =
     boost::variant<None, std::string, double, int, LonLat, boost::local_time::local_date_time>;
 
-
 // Local time pool
 class LocalTimePool
 {
-public:  
-  const boost::local_time::local_date_time& create(const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz);
+ public:
+  const boost::local_time::local_date_time& create(const boost::posix_time::ptime& t,
+                                                   const boost::local_time::time_zone_ptr& tz);
   size_t size() const;
   void print(std::ostream& os) const;
-private:
+
+ private:
   std::map<std::string, boost::local_time::local_date_time> localtimes;
 };
 
@@ -60,11 +61,19 @@ using LocalTimePoolPtr = boost::shared_ptr<LocalTimePool>;
 struct TimedValue
 {
   TimedValue(const boost::local_time::local_date_time& timestamp, const Value& val)
-	: time(const_cast<boost::local_time::local_date_time&>(timestamp)), value(val)
+      : time(const_cast<boost::local_time::local_date_time&>(timestamp)), value(val)
   {
   }
-  TimedValue(const TimedValue& tv) : time(const_cast<boost::local_time::local_date_time&>(tv.time)), value(tv.value) {}
-  TimedValue& operator=(const TimedValue& tv) { time = const_cast<boost::local_time::local_date_time&>(tv.time); value = tv.value; return *this; }
+  TimedValue(const TimedValue& tv)
+      : time(const_cast<boost::local_time::local_date_time&>(tv.time)), value(tv.value)
+  {
+  }
+  TimedValue& operator=(const TimedValue& tv)
+  {
+    time = const_cast<boost::local_time::local_date_time&>(tv.time);
+    value = tv.value;
+    return *this;
+  }
 
   boost::local_time::local_date_time& time;
   Value value;
@@ -74,18 +83,22 @@ using TimedValueVector = std::vector<TimedValue>;
 
 class TimeSeries : public TimedValueVector
 {
-public:
+ public:
   TimeSeries(LocalTimePoolPtr time_pool);
   void emplace_back(const TimedValue& tv);
   void push_back(const TimedValue& tv);
   TimedValueVector::iterator insert(TimedValueVector::iterator pos, const TimedValue& tv);
-  void insert(TimedValueVector::iterator pos, TimedValueVector::iterator first, TimedValueVector::iterator last);
-  void insert(TimedValueVector::iterator pos, TimedValueVector::const_iterator first, TimedValueVector::const_iterator last);
+  void insert(TimedValueVector::iterator pos,
+              TimedValueVector::iterator first,
+              TimedValueVector::iterator last);
+  void insert(TimedValueVector::iterator pos,
+              TimedValueVector::const_iterator first,
+              TimedValueVector::const_iterator last);
   TimeSeries& operator=(const TimeSeries& ts);
-  
+
   LocalTimePoolPtr getLocalTimePool() const { return local_time_pool; }
 
-private:
+ private:
   LocalTimePoolPtr local_time_pool{nullptr};
 };
 

--- a/spine/TimeSeries.h
+++ b/spine/TimeSeries.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/variant.hpp>
@@ -42,19 +43,53 @@ struct None
 using Value =
     boost::variant<None, std::string, double, int, LonLat, boost::local_time::local_date_time>;
 
-// time series variable for a point
+
+// Local time pool
+class LocalTimePool
+{
+public:  
+  const boost::local_time::local_date_time& create(const boost::posix_time::ptime& t, const boost::local_time::time_zone_ptr& tz);
+  size_t size() const;
+  void print(std::ostream& os) const;
+private:
+  std::map<std::string, boost::local_time::local_date_time> localtimes;
+};
+
+using LocalTimePoolPtr = boost::shared_ptr<LocalTimePool>;
+
 struct TimedValue
 {
-  TimedValue(const boost::local_time::local_date_time& timestamp, Value val)
-      : time(timestamp), value(val)
+  TimedValue(const boost::local_time::local_date_time& timestamp, const Value& val)
+	: time(const_cast<boost::local_time::local_date_time&>(timestamp)), value(val)
   {
   }
-  boost::local_time::local_date_time time;
+  TimedValue(const TimedValue& tv) : time(const_cast<boost::local_time::local_date_time&>(tv.time)), value(tv.value) {}
+  TimedValue& operator=(const TimedValue& tv) { time = const_cast<boost::local_time::local_date_time&>(tv.time); value = tv.value; return *this; }
+
+  boost::local_time::local_date_time& time;
   Value value;
 };
 
+using TimedValueVector = std::vector<TimedValue>;
+
+class TimeSeries : public TimedValueVector
+{
+public:
+  TimeSeries(LocalTimePoolPtr time_pool);
+  void emplace_back(const TimedValue& tv);
+  void push_back(const TimedValue& tv);
+  TimedValueVector::iterator insert(TimedValueVector::iterator pos, const TimedValue& tv);
+  void insert(TimedValueVector::iterator pos, TimedValueVector::iterator first, TimedValueVector::iterator last);
+  void insert(TimedValueVector::iterator pos, TimedValueVector::const_iterator first, TimedValueVector::const_iterator last);
+  TimeSeries& operator=(const TimeSeries& ts);
+  
+  LocalTimePoolPtr getLocalTimePool() const { return local_time_pool; }
+
+private:
+  LocalTimePoolPtr local_time_pool{nullptr};
+};
+
 // one time series
-using TimeSeries = std::vector<TimedValue>;
 using TimeSeriesPtr = boost::shared_ptr<TimeSeries>;
 
 // time series result variable for an area
@@ -75,6 +110,8 @@ using TimeSeriesVectorPtr = boost::shared_ptr<TimeSeriesVector>;
 
 template <>
 bool None::operator==(const None& other) const;
+
+std::ostream& operator<<(std::ostream& os, const LocalTimePool& localTimePool);
 
 }  // namespace TimeSeries
 }  // namespace Spine

--- a/spine/TimeSeriesAggregator.cpp
+++ b/spine/TimeSeriesAggregator.cpp
@@ -441,8 +441,8 @@ TimeSeries area_aggregate(const TimeSeriesGroup& ts_group, const ParameterFuncti
           statcalculator(tv);
       }
       // take timestamps from first location (they are same for all locations inside area)
-      const boost::local_time::local_date_time&  timestamp = ts_group[0].timeseries[i].time;
-      
+      const boost::local_time::local_date_time& timestamp = ts_group[0].timeseries[i].time;
+
       ret.emplace_back(TimedValue(timestamp, statcalculator.getStatValue(func, false)));
     }
 

--- a/spine/TimeSeriesAggregator.cpp
+++ b/spine/TimeSeriesAggregator.cpp
@@ -41,6 +41,7 @@ class StatCalculator
   boost::optional<boost::local_time::local_date_time> itsTimestep;
 
  public:
+  StatCalculator(LocalTimePoolPtr time_pool) : itsTimeSeries(time_pool) {}
   void operator()(const TimedValue& tv);
   Value getStatValue(const ParameterFunction& func, bool useWeights) const;
   void setTimestep(const boost::local_time::local_date_time& timestep) { itsTimestep = timestep; }
@@ -417,7 +418,7 @@ TimeSeries area_aggregate(const TimeSeriesGroup& ts_group, const ParameterFuncti
 {
   try
   {
-    TimeSeries ret;
+    TimeSeries ret(ts_group.empty() ? nullptr : ts_group[0].timeseries.getLocalTimePool());
 
     if (ts_group.empty())
     {
@@ -430,7 +431,7 @@ TimeSeries area_aggregate(const TimeSeriesGroup& ts_group, const ParameterFuncti
     // iterate through timesteps
     for (size_t i = 0; i < ts_size; i++)
     {
-      StatCalculator statcalculator;
+      StatCalculator statcalculator(ts_group[0].timeseries.getLocalTimePool());
 
       // iterate through locations
       for (const auto& t : ts_group)
@@ -440,8 +441,8 @@ TimeSeries area_aggregate(const TimeSeriesGroup& ts_group, const ParameterFuncti
           statcalculator(tv);
       }
       // take timestamps from first location (they are same for all locations inside area)
-      boost::local_time::local_date_time timestamp(ts_group[0].timeseries[i].time);
-
+      const boost::local_time::local_date_time&  timestamp = ts_group[0].timeseries[i].time;
+      
       ret.emplace_back(TimedValue(timestamp, statcalculator.getStatValue(func, false)));
     }
 
@@ -457,7 +458,7 @@ TimeSeriesPtr time_aggregate(const TimeSeries& ts, const ParameterFunction& func
 {
   try
   {
-    TimeSeriesPtr ret(new TimeSeries());
+    TimeSeriesPtr ret(new TimeSeries(ts.getLocalTimePool()));
 
     std::vector<std::pair<int, int> > agg_indexes = get_aggregation_indexes(func, ts);
 
@@ -472,7 +473,7 @@ TimeSeriesPtr time_aggregate(const TimeSeries& ts, const ParameterFunction& func
         continue;
       }
 
-      StatCalculator statcalculator;
+      StatCalculator statcalculator(ts.getLocalTimePool());
       statcalculator.setTimestep(ts[i].time);
       for (int k = agg_index_start; k <= agg_index_end; k++)
       {
@@ -521,11 +522,11 @@ TimeSeriesPtr aggregate(const TimeSeries& ts, const ParameterFunctions& pf)
 {
   try
   {
-    TimeSeriesPtr ret(new TimeSeries);
+    TimeSeriesPtr ret(new TimeSeries(ts.getLocalTimePool()));
 
     if (pf.innerFunction.type() == FunctionType::AreaFunction)
     {
-      TimeSeries local_ts;
+      TimeSeries local_ts(ts.getLocalTimePool());
       // Do filtering
       for (const auto& tv : ts)
       {

--- a/test/DataFilterTest.cpp
+++ b/test/DataFilterTest.cpp
@@ -1,5 +1,5 @@
-#include <boost/test/included/unit_test.hpp>
 #include "DataFilter.h"
+#include <boost/test/included/unit_test.hpp>
 
 using SmartMet::Spine::DataFilter;
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test_and)
 {
   DataFilter filter;
   filter.setDataFilter("name", "ge 1 AND lt 9");
-  BOOST_CHECK_EQUAL(filter.getSqlClause("name", "x"),std::string("(x < 9 AND x >= 1)"));
+  BOOST_CHECK_EQUAL(filter.getSqlClause("name", "x"), std::string("(x < 9 AND x >= 1)"));
 }
 BOOST_AUTO_TEST_CASE(test_or)
 {

--- a/test/SmartMetCacheTest.cpp
+++ b/test/SmartMetCacheTest.cpp
@@ -7,12 +7,12 @@
 
 #include "SmartMetCache.h"
 #include <boost/make_shared.hpp>
+#include <macgyver/AsyncTask.h>
 #include <regression/tframe.h>
 #include <sys/types.h>
 #include <sstream>
 #include <string>
 #include <unistd.h>
-#include <macgyver/AsyncTask.h>
 
 template <typename T>
 std::string tostr(const T& theValue)
@@ -209,13 +209,13 @@ void cache_in_async_task()
 {
   uid_t uid = getuid();
 
-  Fmi::AsyncTask task(
-      "test",
-      [&uid]() {
-	SmartMet::Spine::SmartMetCache cache(
-	    10, 10, "/tmp/" + std::to_string(int(uid)) + "/bscachetest4");
-	cache.shutdown();
-      });
+  Fmi::AsyncTask task("test",
+                      [&uid]()
+                      {
+                        SmartMet::Spine::SmartMetCache cache(
+                            10, 10, "/tmp/" + std::to_string(int(uid)) + "/bscachetest4");
+                        cache.shutdown();
+                      });
   boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
   task.cancel();
   task.wait();

--- a/test/TimeSeriesAggregatorTest.cpp
+++ b/test/TimeSeriesAggregatorTest.cpp
@@ -10,6 +10,7 @@
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/local_time/local_time.hpp>
 #include <boost/foreach.hpp>
+#include <boost/make_shared.hpp>
 #include <regression/tframe.h>
 
 namespace bp = boost::posix_time;
@@ -27,7 +28,8 @@ ts::TimeSeries generate_observation_timeseries()
 
   bl::time_zone_ptr zone(new bl::posix_time_zone("EET+2"));
 
-  ts::TimeSeries timeseries;
+  auto pool = boost::make_shared<ts::LocalTimePool>();
+  ts::TimeSeries timeseries(pool);
 
   timeseries.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), ts::None()));
@@ -73,7 +75,8 @@ ts::TimeSeries generate_timeseries(bool add_missing_value = false)
 
   bl::time_zone_ptr zone(new bl::posix_time_zone("EET+2"));
 
-  ts::TimeSeries timeseries;
+  auto pool = boost::make_shared<ts::LocalTimePool>();
+  ts::TimeSeries timeseries(pool);
 
   timeseries.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 1.0));
@@ -99,7 +102,8 @@ ts::TimeSeriesGroup generate_timeseries_group()
 
   bl::time_zone_ptr zone(new bl::posix_time_zone("EET+2"));
 
-  ts::TimeSeries timeseries_helsinki;
+  auto pool = boost::make_shared<ts::LocalTimePool>();
+  ts::TimeSeries timeseries_helsinki(pool);
 
   timeseries_helsinki.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 1.0));
@@ -112,7 +116,7 @@ ts::TimeSeriesGroup generate_timeseries_group()
   timeseries_helsinki.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 21.0));
 
-  ts::TimeSeries timeseries_tampere;
+  ts::TimeSeries timeseries_tampere(pool);
 
   timeseries_tampere.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 2.0));
@@ -125,7 +129,7 @@ ts::TimeSeriesGroup generate_timeseries_group()
   timeseries_tampere.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 22.0));
 
-  ts::TimeSeries timeseries_oulu;
+  ts::TimeSeries timeseries_oulu(pool);
 
   timeseries_oulu.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 3.0));
@@ -138,7 +142,7 @@ ts::TimeSeriesGroup generate_timeseries_group()
   timeseries_oulu.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 23.0));
 
-  ts::TimeSeries timeseries_kuopio;
+  ts::TimeSeries timeseries_kuopio(pool);
 
   timeseries_kuopio.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 4.0));
@@ -151,7 +155,7 @@ ts::TimeSeriesGroup generate_timeseries_group()
   timeseries_kuopio.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 24.0));
 
-  ts::TimeSeries timeseries_turku;
+  ts::TimeSeries timeseries_turku(pool);
 
   timeseries_turku.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 5.0));
@@ -186,7 +190,8 @@ ts::TimeSeriesGroup generate_timeseries_group_nans()
 
   bl::time_zone_ptr zone(new bl::posix_time_zone("EET+2"));
 
-  ts::TimeSeries timeseries_helsinki;
+  auto pool = boost::make_shared<ts::LocalTimePool>();
+  ts::TimeSeries timeseries_helsinki(pool);
 
   timeseries_helsinki.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 1.0));
@@ -200,7 +205,7 @@ ts::TimeSeriesGroup generate_timeseries_group_nans()
   timeseries_helsinki.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 21.0));
 
-  ts::TimeSeries timeseries_tampere;
+  ts::TimeSeries timeseries_tampere(pool);
 
   timeseries_tampere.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 2.0));
@@ -214,7 +219,7 @@ ts::TimeSeriesGroup generate_timeseries_group_nans()
   timeseries_tampere.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 22.0));
 
-  ts::TimeSeries timeseries_oulu;
+  ts::TimeSeries timeseries_oulu(pool);
 
   timeseries_oulu.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 3.0));
@@ -227,7 +232,7 @@ ts::TimeSeriesGroup generate_timeseries_group_nans()
   timeseries_oulu.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 23.0));
 
-  ts::TimeSeries timeseries_kuopio;
+  ts::TimeSeries timeseries_kuopio(pool);
 
   timeseries_kuopio.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 4.0));
@@ -240,7 +245,7 @@ ts::TimeSeriesGroup generate_timeseries_group_nans()
   timeseries_kuopio.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(26)), zone), 24.0));
 
-  ts::TimeSeries timeseries_turku;
+  ts::TimeSeries timeseries_turku(pool);
 
   timeseries_turku.push_back(ts::TimedValue(
       bl::local_date_time(bp::ptime(bg::date(2015, 9, 2), bp::hours(22)), zone), 5.0));


### PR DESCRIPTION
…_date_time objects (BRAINSTORM-2122)