### PR TITLE
HTTP update 202512

### DIFF
--- a/spine/HTTP.cpp
+++ b/spine/HTTP.cpp
@@ -576,7 +576,8 @@ std::string Request::toString() const
             }
           }
 
-          if (isFormUrlEncoded)
+          // Generate body content if form encoded and content not explicitly given
+          if (isFormUrlEncoded && !itsContent.empty())
           {
             // Serialize parameters as URL-encoded form data
             auto nextToLast = itsParameters.end();

--- a/spine/HTTP.h
+++ b/spine/HTTP.h
@@ -565,6 +565,15 @@ class Response : public Message
 
   // ----------------------------------------------------------------------
   /*!
+   * \brief Get decoded response content based on Content-Encoding header
+   * Supports: gzip, compress, deflate, zstd, xz, and lzma encodings
+   * Returns the original content if no Content-Encoding or unsupported encoding
+   */
+  // ----------------------------------------------------------------------
+  std::string getDecodedContent();
+
+  // ----------------------------------------------------------------------
+  /*!
    * \brief Get content length
    * This returns numeric_limits<size_t>::max() if message type is stream
    * with unknown size

--- a/spine/HTTP.h
+++ b/spine/HTTP.h
@@ -800,6 +800,15 @@ std::pair<ParsingStatus, std::unique_ptr<Request>> parseRequest(const std::strin
 std::tuple<ParsingStatus, std::unique_ptr<Response>, std::string::const_iterator> parseResponse(
     const std::string& message);
 
+// ----------------------------------------------------------------------
+/*!
+ * Parse HTTP response including body. Handles binary content with null bytes.
+ * The body is stored in the Response object as a vector of chars.
+ */
+// ----------------------------------------------------------------------
+std::pair<ParsingStatus, std::unique_ptr<Response>> parseResponseFull(
+    const std::string& message);
+
 }  // namespace HTTP
 }  // namespace Spine
 }  // namespace SmartMet


### PR DESCRIPTION
Improvements to SmartMet::Spine::HTTP generated by GitHub CoPilot agent (Claude Sonnet 4.5):

1. Current parseResponse() ei ole muutettu, but now there is new parseFullResponse() which extracts also response content. parseResponse() does not and is in use currently
2. Response::getContent() is not changed, but now there is new Response::getDecodedContent() which handles possible content compression
3. Request::toString() is changed to add content in case of **application/x-www-form-urlencoded** (additional condition required: only when content is not alreadys set)
