### PR TITLE
Log correct body size and total time for streamed responses

### DIFF
--- a/smartmet-library-spine.spec
+++ b/smartmet-library-spine.spec
@@ -3,8 +3,8 @@
 %define SPECNAME smartmet-library-%{DIRNAME}
 Summary: SmartMet Server core helper classes
 Name: %{SPECNAME}
-Version: 26.4.27
-Release: 2%{?dist}.fmi
+Version: 26.6.15
+Release: 1%{?dist}.fmi
 License: MIT
 Group: BrainStorm/Development
 URL: https://github.com/fmidev/smartmet-library-spine
@@ -168,6 +168,30 @@ make %{_smp_mflags}
 %{_bindir}/smartmet-plugin-test
 
 %changelog
+* Mon Jun 15 2026 Mika Heiskanen <mika.heiskanen@fmi.fi> - 26.6.15-1.fmi
+- Streamed responses now log the correct body size and total
+  execution time. Access logging for a streamed/chunked response is
+  deferred until the server connection layer has sent the final
+  chunk: HandlerView::handle registers a completion handler on the
+  Response (HTTP::Response::setStreamCompletionHandler /
+  runStreamCompletionHandler), which the server invokes with the
+  actual number of body bytes streamed. The logged duration then
+  spans handler start to last-chunk-sent, and the size is the real
+  total instead of 0. Requires the matching smartmet-server change.
+  CPU time is unchanged and unaffected: it is not part of the
+  access-log file (it only feeds the admin servicestats metric), so
+  for streamed responses it keeps measuring the handler thread as
+  before.
+- Response::getContentLength() no longer returns the size_t(-1)
+  "unknown size" sentinel for streamed responses sent with chunked
+  transfer encoding (setContent(streamer) with no declared length).
+  It now reports 0 in that case. Previously the sentinel
+  (18446744073709551615) was written verbatim as the byte count in
+  the access log, corrupting any downstream byte-sum analysis.
+  Chunked responses use Transfer-Encoding rather than Content-Length,
+  so on-the-wire framing is unaffected. This remains the fallback for
+  any streamed response whose completion handler never fires.
+
 * Mon Apr 27 2026 Mika Heiskanen <mika.heiskanen@fmi.fi> - 26.4.27-2.fmi
 - Per-handler CPU time tracking. HandlerView::handle now
   brackets each handler invocation with

--- a/spine/HTTP.cpp
+++ b/spine/HTTP.cpp
@@ -1049,7 +1049,40 @@ std::string Response::getDecodedContent()
 
 std::size_t Response::getContentLength() const
 {
-  return itsContent.size();
+  // A streamed response with no declared length (the chunked-send path,
+  // setContent(streamer)) stores size_t(-1) as an "unknown size" sentinel.
+  // That value must never escape as a real byte count: it would corrupt the
+  // access log (and anything else summing content lengths) with a ~16 EB
+  // figure. The true streamed size is not known until the connection layer
+  // finishes sending the chunks, long after this is read, so report 0
+  // ("unknown") rather than the sentinel. Responses streamed with a known
+  // size, and all non-streamed responses, are unaffected.
+  const auto length = itsContent.size();
+  if (length == std::numeric_limits<std::size_t>::max())
+    return 0;
+  return length;
+}
+
+void Response::setStreamCompletionHandler(StreamCompletionHandler handler)
+{
+  itsStreamCompletionHandler = std::move(handler);
+}
+
+bool Response::hasStreamCompletionHandler() const
+{
+  return static_cast<bool>(itsStreamCompletionHandler);
+}
+
+void Response::runStreamCompletionHandler(std::size_t bytesSent)
+{
+  // Run at most once: move the handler out before calling so any extra
+  // invocations from the connection's terminal paths (success, error,
+  // teardown) become no-ops. Safe to call on responses without a handler.
+  if (!itsStreamCompletionHandler)
+    return;
+  auto handler = std::move(itsStreamCompletionHandler);
+  itsStreamCompletionHandler = nullptr;
+  handler(*this, bytesSent);
 }
 
 void Response::appendContent(const std::string& bodyPart)

--- a/spine/HTTP.h
+++ b/spine/HTTP.h
@@ -16,6 +16,7 @@
 // For asio buffer types
 #include <boost/asio/buffer.hpp>
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -691,6 +692,24 @@ class Response : public Message
 
   // ----------------------------------------------------------------------
   /*!
+   * \brief Deferred access-log finalizer for streamed responses.
+   *
+   * The body size and the true wall-clock duration of a streamed response
+   * are not known when the handler returns: the data is produced and sent
+   * chunk by chunk later, by the server connection layer. HandlerView sets
+   * this handler for such responses; the connection invokes it exactly once,
+   * once the final chunk has been sent, passing the actual number of body
+   * bytes streamed. The handler then writes the access-log entry with the
+   * real size and total duration. No-op for non-streamed responses.
+   */
+  // ----------------------------------------------------------------------
+  using StreamCompletionHandler = std::function<void(const Response&, std::size_t bytesSent)>;
+  void setStreamCompletionHandler(StreamCompletionHandler handler);
+  bool hasStreamCompletionHandler() const;
+  void runStreamCompletionHandler(std::size_t bytesSent);
+
+  // ----------------------------------------------------------------------
+  /*!
    * \brief Get response status as as string
    */
   // ----------------------------------------------------------------------
@@ -764,6 +783,8 @@ class Response : public Message
 
   std::string itsOriginatingBackend;
   int itsBackendPort = 0;
+
+  StreamCompletionHandler itsStreamCompletionHandler;
 };
 
 // ----------------------------------------------------------------------

--- a/spine/HandlerView.cpp
+++ b/spine/HandlerView.cpp
@@ -259,34 +259,55 @@ bool HandlerView::handle(Reactor& theReactor,
           Fmi::Seconds(static_cast<int>(cpu_secs)) +
           Fmi::Microseconds(static_cast<int>(cpu_nsec / 1000));
 
-      WriteLock lock(itsLoggingMutex);
-
-      auto etag   = theResponse.getHeader("ETag");
       auto apikey = FmiApiKey::getFmiApiKey(theRequest);
+      const std::string apikeyStr = (apikey ? *apikey : "-");
 
-      // Build the LoggedRequest used by both file access log and OTel
-      const LoggedRequest logged(theRequest.getURI(),
-                                 Fmi::MicrosecClock::local_time(),
-                                 accessDuration,
-                                 cpuDuration,
-                                 theResponse.getStatusString(),
-                                 theRequest.getClientIP(),
-                                 theRequest.getMethodString(),
-                                 theResponse.getVersion(),
-                                 theResponse.getContentLength(),
-                                 (etag ? *etag : "-"),
-                                 (apikey ? *apikey : "-"));
-
-      if (isLogging)  // Need to check this again because it may have changed in previous request
+      if (theResponse.hasStreamContent())
       {
-        // Insert new request to the logging list
-        itsRequestLog.push_back(logged);
+        // Streamed response: the body size and the true wall-clock duration
+        // are not known yet — the data is produced and sent chunk by chunk by
+        // the connection layer after this returns. Defer the access-log write
+        // to stream completion. Capture the request-derived fields and the
+        // handler-start instant (before) by value; the connection invokes the
+        // handler with the actual bytes streamed, and the total duration is
+        // measured to that moment. cpuDuration is the handler-thread CPU time
+        // as measured before — unchanged here, and not part of the file access
+        // log in any case (it only feeds the admin servicestats metric).
+        const std::string uri    = theRequest.getURI();
+        const std::string ip     = theRequest.getClientIP();
+        const std::string method = theRequest.getMethodString();
+        theResponse.setStreamCompletionHandler(
+            [this, uri, ip, method, apikeyStr, before, cpuDuration](const HTTP::Response& response,
+                                                                    std::size_t bytesSent)
+            {
+              const auto totalDuration = Fmi::MicrosecClock::universal_time() - before;
+              auto etag = response.getHeader("ETag");
+              appendLoggedRequest(uri,
+                                  totalDuration,
+                                  cpuDuration,
+                                  response.getStatusString(),
+                                  ip,
+                                  method,
+                                  response.getVersion(),
+                                  bytesSent,
+                                  (etag ? *etag : "-"),
+                                  apikeyStr);
+            });
       }
-
-      // OTel export is independent of file logging toggle.
-      // BatchSpanProcessor queues the span internally and returns immediately.
-      if (itsOTelLog)
-        itsOTelLog->log(logged);
+      else
+      {
+        auto etag = theResponse.getHeader("ETag");
+        appendLoggedRequest(theRequest.getURI(),
+                            accessDuration,
+                            cpuDuration,
+                            theResponse.getStatusString(),
+                            theRequest.getClientIP(),
+                            theRequest.getMethodString(),
+                            theResponse.getVersion(),
+                            theResponse.getContentLength(),
+                            (etag ? *etag : "-"),
+                            apikeyStr);
+      }
 
       if (error)
         std::rethrow_exception(error);
@@ -437,6 +458,51 @@ void HandlerView::cleanLog(const Fmi::DateTime& minTime, bool flush)
     {
       flushLogNolock();
     }
+  }
+  catch (...)
+  {
+    throw Fmi::Exception::Trace(BCP, "Operation failed!");
+  }
+}
+
+void HandlerView::appendLoggedRequest(const std::string& uri,
+                                      Fmi::TimeDuration accessDuration,
+                                      Fmi::TimeDuration cpuDuration,
+                                      const std::string& status,
+                                      const std::string& ip,
+                                      const std::string& method,
+                                      const std::string& version,
+                                      std::size_t contentLength,
+                                      const std::string& etag,
+                                      const std::string& apikey)
+{
+  try
+  {
+    WriteLock lock(itsLoggingMutex);
+
+    // Build the LoggedRequest used by both file access log and OTel.
+    // requestEndTime is taken now, i.e. at handler return for normal
+    // responses and at stream completion for deferred streamed ones.
+    const LoggedRequest logged(uri,
+                               Fmi::MicrosecClock::local_time(),
+                               accessDuration,
+                               cpuDuration,
+                               status,
+                               ip,
+                               method,
+                               version,
+                               contentLength,
+                               etag,
+                               apikey);
+
+    // isLogging may have changed since the request started.
+    if (isLogging)
+      itsRequestLog.push_back(logged);
+
+    // OTel export is independent of file logging toggle.
+    // BatchSpanProcessor queues the span internally and returns immediately.
+    if (itsOTelLog)
+      itsOTelLog->log(logged);
   }
   catch (...)
   {

--- a/spine/HandlerView.h
+++ b/spine/HandlerView.h
@@ -103,6 +103,22 @@ class HandlerView
  private:
   void flushLogNolock();
 
+  // Assemble a LoggedRequest from its fields and append it to the in-memory
+  // request log (when logging is enabled) and the OTel trace export. Takes
+  // itsLoggingMutex internally. Used both for the immediate (non-streamed)
+  // logging path and, deferred, for streamed responses once the connection
+  // layer reports the actual number of body bytes streamed.
+  void appendLoggedRequest(const std::string& uri,
+                           Fmi::TimeDuration accessDuration,
+                           Fmi::TimeDuration cpuDuration,
+                           const std::string& status,
+                           const std::string& ip,
+                           const std::string& method,
+                           const std::string& version,
+                           std::size_t contentLength,
+                           const std::string& etag,
+                           const std::string& apikey);
+
   // The actual handler functor
   const ContentHandler itsHandler;
 

--- a/test/HTTPTest.cpp
+++ b/test/HTTPTest.cpp
@@ -1329,6 +1329,131 @@ void response_parse_full_with_null_bytes()
   }
 }
 
+// Minimal one-shot streamer for the content-length tests below.
+class TestStreamer : public SmartMet::Spine::HTTP::ContentStreamer
+{
+ public:
+  std::string getChunk() override
+  {
+    if (itsDone)
+    {
+      setStatus(StreamerStatus::EXIT_OK);
+      return "";
+    }
+    itsDone = true;
+    return "chunk";
+  }
+
+ private:
+  bool itsDone = false;
+};
+
+void response_content_length_string()
+{
+  // A plain string response reports its real byte count.
+  SmartMet::Spine::HTTP::Response response;
+  response.setContent(std::string("Hello, World!"));
+  response.setStatus(SmartMet::Spine::HTTP::Status::ok);
+
+  if (response.getContentLength() == 13)
+  {
+    TEST_PASSED();
+  }
+  else
+  {
+    TEST_FAILED("Expected content length 13, got " +
+                std::to_string(response.getContentLength()));
+  }
+}
+
+void response_content_length_chunked_stream_is_zero()
+{
+  // A streamed response sent with chunked transfer encoding has no declared
+  // length; getContentLength() must report 0 ("unknown"), NOT the internal
+  // size_t(-1) sentinel that would corrupt access-log byte sums.
+  SmartMet::Spine::HTTP::Response response;
+  response.setContent(std::make_shared<TestStreamer>());
+  response.setStatus(SmartMet::Spine::HTTP::Status::ok);
+
+  if (!response.getChunked())
+  {
+    TEST_FAILED("Unsized streamer response should be marked chunked");
+  }
+
+  if (response.getContentLength() == 0)
+  {
+    TEST_PASSED();
+  }
+  else
+  {
+    TEST_FAILED("Chunked stream content length should be 0, got " +
+                std::to_string(response.getContentLength()));
+  }
+}
+
+void response_content_length_sized_stream()
+{
+  // A streamed response with an explicitly declared size keeps that size.
+  SmartMet::Spine::HTTP::Response response;
+  response.setContent(std::make_shared<TestStreamer>(), 1234);
+  response.setStatus(SmartMet::Spine::HTTP::Status::ok);
+
+  if (response.getContentLength() == 1234)
+  {
+    TEST_PASSED();
+  }
+  else
+  {
+    TEST_FAILED("Sized stream content length should be 1234, got " +
+                std::to_string(response.getContentLength()));
+  }
+}
+
+void response_stream_completion_handler()
+{
+  // The deferred access-log finalizer must: be absent by default, fire once
+  // with the reported byte count and a reference to the response, and become
+  // a no-op after firing (so the connection's success + error paths can both
+  // call it safely).
+  SmartMet::Spine::HTTP::Response response;
+  response.setStatus(SmartMet::Spine::HTTP::Status::ok);
+
+  if (response.hasStreamCompletionHandler())
+    TEST_FAILED("Fresh response should have no stream completion handler");
+
+  // No-op when unset must not throw.
+  response.runStreamCompletionHandler(123);
+
+  int calls = 0;
+  std::size_t seen = 0;
+  const SmartMet::Spine::HTTP::Response* seenResponse = nullptr;
+  response.setStreamCompletionHandler(
+      [&](const SmartMet::Spine::HTTP::Response& r, std::size_t bytesSent)
+      {
+        ++calls;
+        seen = bytesSent;
+        seenResponse = &r;
+      });
+
+  if (!response.hasStreamCompletionHandler())
+    TEST_FAILED("Handler should be set after setStreamCompletionHandler");
+
+  response.runStreamCompletionHandler(4096);
+  response.runStreamCompletionHandler(9999);  // must be a no-op (run once)
+
+  if (calls != 1)
+    TEST_FAILED("Stream completion handler must fire exactly once, fired " +
+                std::to_string(calls) + " times");
+  if (seen != 4096)
+    TEST_FAILED("Handler got wrong byte count: " + std::to_string(seen));
+  if (seenResponse != &response)
+    TEST_FAILED("Handler did not receive the originating response");
+  if (response.hasStreamCompletionHandler())
+    TEST_FAILED("Handler should be cleared after firing");
+
+  TEST_PASSED();
+}
+
 class tests : public tframe::tests
 {
   virtual const char* error_message_prefix() const { return "\n\t"; }
@@ -1373,6 +1498,10 @@ class tests : public tframe::tests
     TEST(response_decoded_content_gzip);
     TEST(response_parse_full);
     TEST(response_parse_full_with_null_bytes);
+    TEST(response_content_length_string);
+    TEST(response_content_length_chunked_stream_is_zero);
+    TEST(response_content_length_sized_stream);
+    TEST(response_stream_completion_handler);
   }
 };
 }  // namespace HTTPTest


### PR DESCRIPTION
## Summary
Access logging of a streamed/chunked response happened when the handler returned, but the body is produced and sent chunk by chunk by the connection layer *afterwards* — so the logged size was the `size_t(-1)` "unknown size" sentinel and the duration covered only handler setup.

Logging is now **deferred to stream completion**: `HandlerView::handle` registers a completion handler on the `Response` (`setStreamCompletionHandler` / `runStreamCompletionHandler`, run-once) that the server connection layer invokes with the actual number of body bytes streamed. The logged duration then spans handler start → last-chunk-sent, and the size is the real total.

`Response::getContentLength()` also maps the `size_t(-1)` unknown-size sentinel to 0, as a fallback for any streamed response whose completion handler never fires.

CPU time is unchanged and unaffected: it is not part of the access-log file (only the admin servicestats metric), so for streamed responses it keeps measuring the handler thread as before.

## Cross-repo dependency
Requires the companion **smartmet-server** PR (`download-access-log-fix`) to report the byte total. **Land together, spine first.** The client-side guard lives in **smartmet-monitor** (`download-access-log-fix`).

## Test plan
- `HTTPTest`: 43 cases pass, including 4 new ones (content-length string / chunked-stream / sized-stream, and the completion-handler contract).
- Full spine test suite green, except the pre-existing unrelated `SmartMetCacheTest` (macgyver `EMPTY_CACHE_STATS` env mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)